### PR TITLE
[GH-#65] Added implementation of point addition

### DIFF
--- a/lib/elixir_wallet/key_pair.ex
+++ b/lib/elixir_wallet/key_pair.ex
@@ -163,13 +163,6 @@ defmodule KeyPair do
       :crypto.hmac(:sha512, key.chain_code,
         <<serialized_pub_key::binary, index::size(32)>>)
 
-    ##{point, _} = :crypto.generate_key(:ecdh, :secp256k1, derived_key)
-
-    #<<point_int::size(520)>> = point
-    #<<parent_key_int::size(264)>> = serialized_pub_key
-
-    #child_key = :binary.encode_unsigned(point_int + parent_key_int)
-
     {:ok, child_key} = :libsecp256k1.ec_pubkey_tweak_add(key.key, derived_key)
 
     KeyPair.derive_key(key, child_key, child_chain, index)

--- a/lib/elixir_wallet/key_pair.ex
+++ b/lib/elixir_wallet/key_pair.ex
@@ -118,8 +118,9 @@ defmodule KeyPair do
       type)
   end
 
-  def derive_pathlist(key, [], :private), do: key
-  def derive_pathlist(key, [], :public), do: KeyPair.to_public_key(key)
+  def derive_pathlist(%PrivKey{} = key, [], :private), do: key
+  def derive_pathlist(%PrivKey{} = key, [], :public), do: KeyPair.to_public_key(key)
+  def derive_pathlist(%PubKey{} = key, [], :public), do: key
   def derive_pathlist(key, pathlist, type) do
     [index | rest] = pathlist
     key
@@ -158,16 +159,19 @@ defmodule KeyPair do
     # Normal derivation
     serialized_pub_key = KeyPair.compress(key.key)
 
-    <<derived_key::size(256), child_chain::binary>> =
+    <<derived_key::binary-32, child_chain::binary>> =
       :crypto.hmac(:sha512, key.chain_code,
         <<serialized_pub_key::binary, index::size(32)>>)
 
-    {point, _} = :crypto.generate_key(:ecdh, :secp256k1, derived_key)
+    ##{point, _} = :crypto.generate_key(:ecdh, :secp256k1, derived_key)
 
-    <<point_int::size(520)>> = point
-    <<parent_key_int::size(264)>> = serialized_pub_key
+    #<<point_int::size(520)>> = point
+    #<<parent_key_int::size(264)>> = serialized_pub_key
 
-    child_key = :binary.encode_unsigned(point_int + parent_key_int)
+    #child_key = :binary.encode_unsigned(point_int + parent_key_int)
+
+    {:ok, child_key} = :libsecp256k1.ec_pubkey_tweak_add(key.key, derived_key)
+
     KeyPair.derive_key(key, child_key, child_chain, index)
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -26,11 +26,10 @@ defmodule ElixirWallet.Mixfile do
       {:base58check, github: "quanterall/base58check"},
       {:seed_generator, github: "quanterall/seed_generator"},
       {:httpoison, "~> 0.13.0"},
+      {:libsecp256k1, [github: "mbrix/libsecp256k1", manager: :rebar]},
       {:poison, "~> 3.1"},
       {:excoveralls, "~> 0.7", only: :test},
       {:credo, "~> 0.8", only: [:dev, :test], runtime: false}
-      # {:dep_from_hexpm, "~> 0.3.0"},
-      # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"},
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -8,6 +8,7 @@
   "httpoison": {:hex, :httpoison, "0.13.0", "bfaf44d9f133a6599886720f3937a7699466d23bb0cd7a88b6ba011f53c6f562", [], [{:hackney, "~> 1.8", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "idna": {:hex, :idna, "5.1.0", "d72b4effeb324ad5da3cab1767cb16b17939004e789d8c0ad5b70f3cea20c89a", [], [{:unicode_util_compat, "0.3.1", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm"},
   "jsx": {:hex, :jsx, "2.8.3", "a05252d381885240744d955fbe3cf810504eb2567164824e19303ea59eef62cf", [], [], "hexpm"},
+  "libsecp256k1": {:git, "https://github.com/mbrix/libsecp256k1.git", "671be513a6c19db47fbeea0ceefbf61421d196cc", []},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [], [], "hexpm"},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [], [], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [], [], "hexpm"},

--- a/test/child_key_derivation.ex
+++ b/test/child_key_derivation.ex
@@ -177,17 +177,17 @@ test "bip32_vectors_1_btc" do
 
 
   ## The child pub key from a parent pub key derivation is not working, looking for a solution!!!
-  #test "public_derivation" do
-  #  seed = "000102030405060708090a0b0c0d0e0f" |> Base.decode16!(case: :mixed)
-  #  master_key = KeyPair.generate_master_key(seed, :seed)
-  #  public_master_key =
-  #    master_key
-  #    |> KeyPair.derive("m/0'/1/2'/2")
-  #    |> KeyPair.generate_master_key(:public)
-  #  public_child_key = public_master_key |> KeyPair.derive("m/1000000000")
+  test "public_derivation" do
+    seed = "000102030405060708090a0b0c0d0e0f" |> Base.decode16!(case: :mixed)
+    master_key = KeyPair.generate_master_key(seed, :seed)
+    public_master_key =
+      master_key
+      |> KeyPair.derive("M/0'/1/2'/2")
+    IO.inspect public_master_key
+    public_child_key = public_master_key |> KeyPair.derive("M/1000000000")
 
     ## Chain m/0h/1/2h/2/1000000000
-  #  assert "xpub6H1LXWLaKsWFhvm6RVpEL9P4KfRZSW7abD2ttkWP3SSQvnyA8FSVqNTEcYFgJS2UaFcxupHiYkro49S8yGasTvXEYBVPamhGW6cFJodrTHy"
-  #  = KeyPair.format_key(public_child_key)
-  #end
+    assert "xpub6H1LXWLaKsWFhvm6RVpEL9P4KfRZSW7abD2ttkWP3SSQvnyA8FSVqNTEcYFgJS2UaFcxupHiYkro49S8yGasTvXEYBVPamhGW6cFJodrTHy"
+    = KeyPair.format_key(public_child_key)
+  end
 end

--- a/test/child_key_derivation.ex
+++ b/test/child_key_derivation.ex
@@ -183,7 +183,6 @@ test "bip32_vectors_1_btc" do
     public_master_key =
       master_key
       |> KeyPair.derive("M/0'/1/2'/2")
-    IO.inspect public_master_key
     public_child_key = public_master_key |> KeyPair.derive("M/1000000000")
 
     ## Chain m/0h/1/2h/2/1000000000


### PR DESCRIPTION
To do so an erlang nif library has been added to the project - [libsecp256k1](https://github.com/mbrix/libsecp256k1)
It uses the Bitcoin secp256k1 C implementation.

To make it work you need to install couple of things beforehand if you don't have them already:
```sudo apt-get install autoconf autogen```
```sudo apt-get install libtool```
```sudo apt-get install libgmp3-dev```

resolves #65 