### PR TITLE
[GH-#96] Added pubkey encoding functionality to a human readable format

### DIFF
--- a/lib/aewallet/elixir_wallet.ex
+++ b/lib/aewallet/elixir_wallet.ex
@@ -168,9 +168,13 @@ defmodule Aewallet.Wallet do
   @spec get_public_key(String.t(), String.t(), network_opts()) :: tuple()
   def get_public_key(path, password, opts \\ []) do
     {:ok, private_key} = Wallet.get_private_key(path, password, opts)
-    public_key = KeyPair.generate_pub_key(private_key)
 
-    {:ok, public_key}
+    compressed_pub_key =
+      private_key
+      |> KeyPair.generate_pub_key()
+      |> KeyPair.compress()
+
+    {:ok, compressed_pub_key}
   end
 
   @doc """

--- a/lib/aewallet/encoding.ex
+++ b/lib/aewallet/encoding.ex
@@ -13,22 +13,20 @@ defmodule Aewallet.Encoding do
   Encodes public key to a human readable format.
 
   ## Examples
-      iex> Aewallet.Encoding.encode(:ae, pub_key)
+      iex> Aewallet.Encoding.encode(compressed_pub_key, :ae)
       "ae1qq04nuehhr26nz7ggtgaqq939f9hsaq5hrlhsjrlcg5wngpq4pzc968kfa8u"
 
-      iex> Aewallet.Encoding.encode(:btc, pub_key)
+      iex> Aewallet.Encoding.encode(compressed_pub_key, :btc)
       "btc1qq04nuehhr26nz7ggtgaqq939f9hsaq5hrlhsjrlcg5wngpq4pzc963alrmy"
   """
   @spec encode(currency(), binary()) :: String.t()
-  def encode(currency, pub_key) do
-    compressed_key = KeyPair.compress(pub_key)
-
+  def encode(compressed_pub_key, currency) do
     case currency do
       :ae ->
-        SegwitAddr.encode("ae", 0, :binary.bin_to_list(compressed_key))
+        SegwitAddr.encode("ae", 0, :binary.bin_to_list(compressed_pub_key))
 
       :btc ->
-        SegwitAddr.encode("btc", 0, :binary.bin_to_list(compressed_key))
+        SegwitAddr.encode("btc", 0, :binary.bin_to_list(compressed_pub_key))
 
       _ ->
         throw("The given currency '#{currency}' is not supported. Please use :ae or :btc")

--- a/lib/aewallet/encoding.ex
+++ b/lib/aewallet/encoding.ex
@@ -1,0 +1,50 @@
+defmodule Aewallet.Encoding do
+  @moduledoc """
+  This module is responsible for encoding the Public keys
+  in Bach32. This implementation is from BIP-0173.
+  """
+
+  alias Aewallet.KeyPair
+
+  @typedoc "Wallet option value"
+  @type currency :: :ae | :btc
+
+  @doc """
+  Encodes public key to a human readable format.
+
+  ## Examples
+      iex> Aewallet.Encoding.encode(:ae, pub_key)
+      "ae1qq04nuehhr26nz7ggtgaqq939f9hsaq5hrlhsjrlcg5wngpq4pzc968kfa8u"
+
+      iex> Aewallet.Encoding.encode(:btc, pub_key)
+      "btc1qq04nuehhr26nz7ggtgaqq939f9hsaq5hrlhsjrlcg5wngpq4pzc963alrmy"
+  """
+  @spec encode(currency(), binary()) :: String.t()
+  def encode(currency, pub_key) do
+    compressed_key = KeyPair.compress(pub_key)
+
+    case currency do
+      :ae ->
+        SegwitAddr.encode("ae", 0, :binary.bin_to_list(compressed_key))
+
+      :btc ->
+        SegwitAddr.encode("btc", 0, :binary.bin_to_list(compressed_key))
+
+      _ ->
+        throw("The given currency '#{currency}' is not supported. Please use :ae or :btc")
+    end
+  end
+
+  @doc """
+  Decodes a encoded public key to it's compressed version
+
+  ## Examples
+      iex> Aewallet.Encoding.decode("ae1qq04nuehhr26nz7ggtgaqq939f9hsaq5hrlhsjrlcg5wngpq4pzc968kfa8u")
+      {:ok, compressed_pubkey}
+  """
+  def decode(encoded) do
+    {:ok, {_prefix, _version, compressed_pub_key}} = SegwitAddr.decode(encoded)
+    {:ok, :binary.list_to_bin(compressed_pub_key)}
+  end
+
+end

--- a/lib/aewallet/key_pair.ex
+++ b/lib/aewallet/key_pair.ex
@@ -345,7 +345,7 @@ defmodule Aewallet.KeyPair do
   end
 
   @spec compress(binary()) :: binary()
-  defp compress(<<_prefix::size(8), x_coordinate::size(256), y_coordinate::size(256)>>) do
+  def compress(<<_prefix::size(8), x_coordinate::size(256), y_coordinate::size(256)>>) do
     prefix = case rem(y_coordinate, 2) do
       0 -> 0x02
       _ -> 0x03

--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,8 @@ defmodule Aewallet.Mixfile do
       {:httpoison, "~> 0.13.0"},
       {:libsecp256k1, [github: "mbrix/libsecp256k1", manager: :rebar]},
       {:excoveralls, "~> 0.7", only: :test},
-      {:credo, "~> 0.8", only: [:dev, :test], runtime: false}
+      {:credo, "~> 0.8", only: [:dev, :test], runtime: false},
+      {:bip0173, "~> 0.1.2"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
 %{"base58check": {:git, "https://github.com/quanterall/base58check.git", "e012da96735852902df672d1543298cdf8f9664c", []},
+  "bip0173": {:hex, :bip0173, "0.1.2", "b771e275692ed3353ecfecb38330693cbba90d2ac4a2e8fd1908a86ec7e6318f", [], [], "hexpm"},
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [], [], "hexpm"},
   "certifi": {:hex, :certifi, "2.0.0", "a0c0e475107135f76b8c1d5bc7efb33cd3815cb3cf3dea7aefdd174dabead064", [], [], "hexpm"},
   "credo": {:hex, :credo, "0.8.10", "261862bb7363247762e1063713bb85df2bbd84af8d8610d1272cd9c1943bba63", [], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}], "hexpm"},

--- a/test/bech32_test.exs
+++ b/test/bech32_test.exs
@@ -1,0 +1,67 @@
+defmodule Bech32DormattingTest do
+  use ExUnit.Case
+  doctest Aewallet
+
+  alias Aewallet.Encoding
+
+  @valid_address [
+    ["BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4", "0014751e76e8199196d454941c45d1b3a323f1433bd6"],
+    ["tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7",
+     "00201863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262"],
+    ["bc1pw508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7k7grplx",
+     "5128751e76e8199196d454941c45d1b3a323f1433bd6751e76e8199196d454941c45d1b3a323f1433bd6"],
+    ["BC1SW50QA3JX3S", "6002751e"],
+    ["bc1zw508d6qejxtdg4y5r3zarvaryvg6kdaj", "5210751e76e8199196d454941c45d1b3a323"],
+    ["tb1qqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesrxh6hy",
+     "0020000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433"],
+  ]
+
+  @invalid_address [
+    "tc1qw508d6qejxtdg4y5r3zarvary0c5xw7kg3g4ty",
+    "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t5",
+    "BC13W508D6QEJXTDG4Y5R3ZARVARY0C5XW7KN40WF2",
+    "bc1rw5uspcuh",
+    "bc10w508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kw5rljs90",
+    "BC1QR508D6QEJXTDG4Y5R3ZARVARYV98GJ9P",
+    "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sL5k7",
+    "bc1zw508d6qejxtdg4y5r3zarvaryvqyzf3du",
+    "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3pjxtptv",
+    "bc1gmk9yu"
+  ]
+
+  test "valid addresses" do
+    for [addr, hex] <- @valid_address do
+      assert {:ok, {hrp, version, program}} = SegwitAddr.decode(addr)
+      assert version != nil
+      assert SegwitAddr.encode(hrp, version, program) == String.downcase(addr)
+      assert SegwitAddr.to_script_pub_key(version, program) == hex
+    end
+  end
+
+  test "invalid address" do
+    for [addr, _hex] <- @invalid_address do
+      assert {:error, _} = SegwitAddr.decode(addr)
+    end
+  end
+
+  test "valid aeternity address" do
+    assert {:ok,
+            <<3, 235, 62, 102, 247, 26, 181, 49, 121, 8, 90, 58, 0, 22, 37, 73, 111, 14,
+            130, 151, 31, 239, 9, 15, 248, 69, 29, 52, 4, 21, 8, 176, 93>>} =
+      Aewallet.Encoding.decode("ae1qq04nuehhr26nz7ggtgaqq939f9hsaq5hrlhsjrlcg5wngpq4pzc968kfa8u")
+  end
+
+  test "invalid aeternity address" do
+    assert {:error, "Invalid checksum"} =
+      Aewallet.Encoding.decode("ae1qq04nuehhr26nz7ggtgaqq939f9hsaq5hrlhsjrlcg5wngpq4pzc968kfa8")
+  end
+
+  test "encode key" do
+    key = <<2, 16, 79, 59, 182, 75, 40, 252, 211, 42, 44, 81, 19, 17, 224, 213, 54, 134,
+      43, 119, 61, 145, 93, 120, 197, 205, 37, 199, 227, 2, 172, 252, 202>>
+    assert "ae1qqggy7wakfv50e5e293g3xy0q65mgv2mh8kg467x9e5ju0ccz4n7v55dnf82" =
+      Encoding.encode(key, :ae)
+    assert "bc1qqggy7wakfv50e5e293g3xy0q65mgv2mh8kg467x9e5ju0ccz4n7v5ysz2ez" =
+      Encoding.encode(key, :btc)
+  end
+end

--- a/test/loading_wallet_public_key_and_address_test.exs
+++ b/test/loading_wallet_public_key_and_address_test.exs
@@ -14,12 +14,12 @@ defmodule LoadPublicKeyAndAddressTest do
       Wallet.get_public_key("test/test_wallets/wallet--2018-1-17-11-59-25", "password")
 
     assert public_key ==
-      Base.decode16!("0443C79213D6301FB19C50CEFCBBC2EE80CD53ACEFE9D4FB1FEE4E1DD3863F643095C24FD54EF4959A554B3461726B789D4D8E0C97526C3A18A39E16B326FF6D5A")
+      Base.decode16!("0243C79213D6301FB19C50CEFCBBC2EE80CD53ACEFE9D4FB1FEE4E1DD3863F6430")
 
     {:ok, address} =
       Wallet.get_address("test/test_wallets/wallet--2018-1-17-11-59-25", "password")
 
-    assert address == "Aw1EeJtR3xNmi5fy6Mu9xL8xqzKPzrY36w"
+    assert address == "ApgKtK5yi3npi3c48U53ESegbHSfsyYWWU"
   end
 
   test "validate master public key and address 2" do
@@ -31,12 +31,12 @@ defmodule LoadPublicKeyAndAddressTest do
       Wallet.get_public_key("test/test_wallets/wallet--2018-1-17-12-9-55", "password")
 
     assert public_key ==
-      Base.decode16!("04C64160211603FB738BFD69AFEC4BC675D7AEDB7BDD06D5CC661D33EA3021AAD4FDA318B310487FBFF91DEC887F13E57394EEBB3FD34876F1793F7D427BD17718")
+      Base.decode16!("02C64160211603FB738BFD69AFEC4BC675D7AEDB7BDD06D5CC661D33EA3021AAD4")
 
     {:ok, address} =
       Wallet.get_address("test/test_wallets/wallet--2018-1-17-12-9-55", "password")
 
-    assert address == "1LZsufgWrF6WbS5e39J4jiMJNwWpHEGA75"
+    assert address == "121jXTz93jqEqDSp2gSJCKTBvbWYWeJD8i"
   end
 
    test "validate master public key and address 3" do
@@ -48,11 +48,11 @@ defmodule LoadPublicKeyAndAddressTest do
       Wallet.get_public_key("test/test_wallets/wallet--2018-1-17-12-12-16", "password")
 
     assert public_key ==
-      Base.decode16!("04169FE30E399CC4B6BF5CFCB8CD7091D462D5B50E8082C7D9C0A54080E77BE056777BB1596050E34462131AA07C24196E108CBD890AC9A7EA19665BB5F6E6A142")
+      Base.decode16!("02169FE30E399CC4B6BF5CFCB8CD7091D462D5B50E8082C7D9C0A54080E77BE056")
 
     {:ok, address} =
       Wallet.get_address("test/test_wallets/wallet--2018-1-17-12-12-16", "password")
 
-    assert address == "Ar4VeTDWQFE97LDFQ2De2Gg4fHf2FHeRqP"
+    assert address == "AsZ6sZxqJrD7WGYBURJnKpxdJKSfyjK1j9"
   end
 end


### PR DESCRIPTION
Used [this](https://github.com/stampery/elixir-bip0173) library for the encoding/decoding

resolves #96 